### PR TITLE
Add support for Travis AARCH64 architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ dist: trusty
 
 git:
   depth: false
-
+arch:
+    - amd64
+    - arm64
 services:
   - docker
 


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI.

Signed-off-by: odidev <odidev@puresoftware.com>
